### PR TITLE
feat(core): USB PID change, switch flag, and logic

### DIFF
--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -85,7 +85,7 @@ static void usb_init_all(secbool usb21_landing) {
       .device_subclass = 0x00,
       .device_protocol = 0x00,
       .vendor_id = 0x1209,
-      .product_id = 0x53C0,
+      .product_id = 0x4F4A,
       .release_num = 0x0200,
       .manufacturer = "OneKey",
       .product = "ONEKEY",

--- a/core/src/main.py
+++ b/core/src/main.py
@@ -34,10 +34,6 @@ if __debug__:
 # as a UI callback for storage, which can be invoked at any time
 import trezor.pin  # noqa: F401
 
-# === Prepare the USB interfaces first. Do not connect to the host yet.
-# usb imports trezor.utils and trezor.io which is a C module
-import usb
-
 
 # create an unimport manager that will be reused in the main loop
 unimport_manager = utils.unimport()
@@ -46,6 +42,11 @@ unimport_manager = utils.unimport()
 with unimport_manager:
     import boot
     del boot
+
+# === Prepare the USB interfaces first. Do not connect to the host yet.
+# usb imports trezor.utils and trezor.io which is a C module
+# Note: "usb" has to be imported after "boot" since it needs "storage"
+import usb
 
 # start the USB
 import storage.device

--- a/core/src/storage/device.py
+++ b/core/src/storage/device.py
@@ -57,6 +57,7 @@ _USE_RANDOM_PIN_MAP = const(0x87)  # bool (0x01 or empty)
 _KEYBOARD_HAPTIC = const(0x88)   # bool
 _TAP_AWAKE = const(0x89)  # bool
 _ANIMATION = const(0x8A)  # bool
+_USE_TREZOR_COMP_MODE = const(0x8B)  # bool
 
 SAFETY_CHECK_LEVEL_STRICT  : Literal[0] = const(0)
 SAFETY_CHECK_LEVEL_PROMPT  : Literal[1] = const(1)
@@ -185,6 +186,14 @@ def is_usb_lock_enabled() -> bool:
 
 def set_usb_lock_enable(enable: bool) -> None:
     common.set_bool(_NAMESPACE, _USE_USB_PROTECT, enable, public=True)
+
+
+def is_trezor_comp_mode_enabled() -> bool:
+    return common.get_bool(_NAMESPACE, _USE_TREZOR_COMP_MODE, public=True)
+
+
+def set_trezor_comp_mode_enable(enable: bool) -> None:
+    common.set_bool(_NAMESPACE, _USE_TREZOR_COMP_MODE, enable, public=True)
 
 
 def is_tap_awake_enabled() -> bool:

--- a/core/src/usb.py
+++ b/core/src/usb.py
@@ -1,10 +1,11 @@
 from micropython import const
 
+from storage import device
 from trezor import io, utils
 
 bus = io.USB(
     vendor_id=0x1209,
-    product_id=0x53C1,
+    product_id=0x53C1 if device.is_trezor_comp_mode_enabled() else 0x4F4B,
     release_num=0x0200,
     manufacturer="OneKey",
     product="OneKey",


### PR DESCRIPTION
Note:
This PR do not contain user interface related code and translations.
PID switch change only applys after device reboot due to how USB was initialized, and as this is not a frequently changed item, we could keep it this way.

For UI implementation, please use `is_trezor_comp_mode_enabled()` and `set_trezor_comp_mode_enable(enable: bool)`.
And also warn user the device has to be rebooted for change to take effect.