### PR TITLE
feat(core): USB PID switch flag and logic

### DIFF
--- a/legacy/firmware/config.c
+++ b/legacy/firmware/config.c
@@ -113,6 +113,8 @@ static const uint32_t META_MAGIC_V10 = 0xFFFFFFFF;
 
 #define KEY_COIN_FUNCTION_SWITCH (39 | APP | FLAG_PUBLIC_SHIFTED)       // uint32
 
+#define KEY_TREZOR_COMP_MODE (40 | APP | FLAG_PUBLIC_SHIFTED)       // bool
+
 #define KEY_DEBUG_LINK_PIN (255 | APP | FLAG_PUBLIC_SHIFTED)            // string(10)
 // clang-format on
 
@@ -683,6 +685,15 @@ void config_setPassphraseProtection(bool passphrase_protection) {
 bool config_getPassphraseProtection(bool *passphrase_protection) {
   return sectrue ==
          config_get_bool(KEY_PASSPHRASE_PROTECTION, passphrase_protection);
+}
+
+void config_setTrezorCompMode(bool trezor_comp_mode) {
+  config_set_bool(KEY_TREZOR_COMP_MODE, trezor_comp_mode);
+}
+
+bool config_getTrezorCompMode(bool *trezor_comp_mode) {
+  return sectrue ==
+         config_get_bool(KEY_TREZOR_COMP_MODE, trezor_comp_mode);
 }
 
 void config_setHomescreen(const uint8_t *data, uint32_t size) {

--- a/legacy/firmware/config.h
+++ b/legacy/firmware/config.h
@@ -125,6 +125,10 @@ bool config_isLanguageSet(void);
 void config_setPassphraseProtection(bool passphrase_protection);
 bool config_getPassphraseProtection(bool *passphrase_protection);
 
+void config_setTrezorCompMode(bool trezor_comp_mode);
+bool config_getTrezorCompMode(bool *trezor_comp_mode);
+
+
 bool config_getHomescreen(uint8_t *dest, uint16_t dest_size);
 void config_setHomescreen(const uint8_t *data, uint32_t size);
 

--- a/legacy/firmware/language.c
+++ b/legacy/firmware/language.c
@@ -1137,6 +1137,8 @@ const char *languages[][2] = {
     {"you still have ", "还有"},
     // reset.c
     {"your asset,Keep it safe", "凭证,请妥善保管"},
+    //
+    {"Trezor Mode", "Trezor模式"},
 };
 
 int LANGUAGE_ITEMS = sizeof(languages) / sizeof(languages[0]);

--- a/legacy/firmware/menu_list.c
+++ b/legacy/firmware/menu_list.c
@@ -352,6 +352,19 @@ static struct menu ble_set_menu = {
     .previous = &settings_menu,
 };
 
+static struct menu_item trezor_comp_mode_set_menu_items[] = {
+    {"On", NULL, true, menu_para_set_trezor_comp_mode, NULL, true},
+    {"Off", NULL, true, menu_para_set_trezor_comp_mode, NULL, true}};
+
+static struct menu trezor_comp_mode_set_menu = {
+    .start = 0,
+    .current = 0,
+    .counts = COUNT_OF(trezor_comp_mode_set_menu_items),
+    .title = NULL,
+    .items = trezor_comp_mode_set_menu_items,
+    .previous = &settings_menu,
+};
+
 static struct menu_item language_set_menu_items[] = {
     {"English ", NULL, true, menu_para_set_language, NULL, true},
     {"简体中文", NULL, true, menu_para_set_language, NULL, true}};
@@ -418,7 +431,9 @@ static struct menu_item settings_menu_items[] = {
     {"AutoLock", NULL, false, .sub_menu = &autolock_set_menu,
      menu_para_autolock, false},
     {"Shutdown", NULL, false, .sub_menu = &shutdown_set_menu,
-     menu_para_shutdown, false}};
+     menu_para_shutdown, false},
+    {"Trezor Mode", NULL, false, .sub_menu = &trezor_comp_mode_set_menu,
+    menu_para_trezor_comp_mode_state, false}};
 
 static struct menu settings_menu = {
     .start = 0,

--- a/legacy/firmware/menu_para.c
+++ b/legacy/firmware/menu_para.c
@@ -84,3 +84,13 @@ void menu_para_set_sleep(int index) {
   uint32_t ms[5] = {60 * 1000, 2 * 60 * 1000, 5 * 60 * 1000, 10 * 60 * 1000, 0};
   config_setSleepDelayMs(ms[index]);
 }
+
+char* menu_para_trezor_comp_mode_state(void) {
+  bool trezor_comp_mode_current = false;
+  config_getTrezorCompMode(&trezor_comp_mode_current);
+  return trezor_comp_mode_current ? _(" On") : _(" Off");
+}
+
+void menu_para_set_trezor_comp_mode(int index) {
+  config_setTrezorCompMode(index ? false : true);
+}

--- a/legacy/firmware/menu_para.h
+++ b/legacy/firmware/menu_para.h
@@ -8,10 +8,12 @@ char* menu_para_autolock(void);
 char* menu_para_eth_eip_switch(void);
 char* menu_para_sol_switch(void);
 char* menu_para_passphrase(void);
+char* menu_para_trezor_comp_mode_state(void);
 
 void menu_para_set_ble(int index);
 void menu_para_set_language(int index);
 void menu_para_set_shutdown(int index);
 void menu_para_set_sleep(int index);
+void menu_para_set_trezor_comp_mode(int index);
 
 #endif

--- a/legacy/firmware/usb.c
+++ b/legacy/firmware/usb.c
@@ -97,7 +97,7 @@ uint16_t s_usOffset;
 static const char *usb_strings[] = {USB_STRINGS};
 #undef X
 
-static const struct usb_device_descriptor dev_descr = {
+static struct usb_device_descriptor dev_descr = {
     .bLength = USB_DT_DEVICE_SIZE,
     .bDescriptorType = USB_DT_DEVICE,
     .bcdUSB = 0x0210,
@@ -106,7 +106,7 @@ static const struct usb_device_descriptor dev_descr = {
     .bDeviceProtocol = 0,
     .bMaxPacketSize0 = USB_PACKET_SIZE,
     .idVendor = 0x1209,
-    .idProduct = 0x53c1,
+    .idProduct = 0x4F4B,
     .bcdDevice = 0x0100,
     .iManufacturer = USB_STRING_MANUFACTURER,
     .iProduct = USB_STRING_PRODUCT,
@@ -408,6 +408,12 @@ static const struct usb_bos_descriptor bos_descriptor = {
     .capabilities = capabilities};
 
 void usbInit(void) {
+
+  bool trezor_comp_mode = false;
+  config_getTrezorCompMode(&trezor_comp_mode);
+  // dev_descr.idProduct = trezor_comp_mode ? 0x53c1 : 0x4F4B;
+  if(trezor_comp_mode) {dev_descr.idProduct = 0x53c1;}
+
   usbd_dev = usbd_init(&otgfs_usb_driver, &dev_descr, &config, usb_strings,
                        sizeof(usb_strings) / sizeof(*usb_strings),
                        usbd_control_buffer, sizeof(usbd_control_buffer));


### PR DESCRIPTION
Note:

PID switch change only applys after device reboot due to how USB was initialized, and as this is not a frequently changed item, we could keep it this way.

Chinese translation of the new menu item not working yet, not sure what I missed.