### PR TITLE
fix(core): the maximum data length supported by `sign_type_data` is c…

### DIFF
--- a/core/src/apps/ethereum/sign_typed_data.py
+++ b/core/src/apps/ethereum/sign_typed_data.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 
 # Maximum data size we support
-MAX_VALUE_BYTE_SIZE = 1024
+MAX_VALUE_BYTE_SIZE = 1536  # 1.5 KB
 
 
 @with_keychain_from_path(*PATTERNS_ADDRESS)


### PR DESCRIPTION
…hanged from 1kb to 1.5kb