### PR TITLE
fix(legacy): move i18n languages item from .bss to .rodata segment wh…

### DIFF
--- a/legacy/firmware/language.c
+++ b/legacy/firmware/language.c
@@ -1,6 +1,6 @@
 #include "language.h"
 
-const char *languages[][2] = {
+const char *const languages[][2] = {
     //
     {" Disabled", "已禁用"},
     {" Enabled", "已启用"},

--- a/legacy/firmware/language.h
+++ b/legacy/firmware/language.h
@@ -1,7 +1,7 @@
 #ifndef __LANGUAGE_H__
 #define __LANGUAGE_H__
 
-extern const char *languages[][2];
+extern const char* const languages[][2];
 
 extern int LANGUAGE_ITEMS;
 


### PR DESCRIPTION
…ich save ram use to avoid stack overflow