### PR TITLE
chore: update ConfluxScan url

### DIFF
--- a/common/defs/conflux/crc20.json
+++ b/common/defs/conflux/crc20.json
@@ -13,7 +13,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -32,7 +32,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -51,7 +51,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -70,7 +70,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -89,7 +89,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -108,7 +108,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -127,7 +127,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -146,7 +146,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -165,7 +165,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -184,7 +184,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -203,7 +203,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -222,7 +222,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -241,7 +241,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false
@@ -260,7 +260,7 @@
     "addToIndex": false,
     "chainId": "1029",
     "source": [
-      "confluxscan.io"
+      "confluxscan.org"
     ],
     "checked": true,
     "isNative": false

--- a/core/.changelog.d/noissue.changed.md
+++ b/core/.changelog.d/noissue.changed.md
@@ -1,0 +1,1 @@
+chore: update ConfluxScan url


### PR DESCRIPTION
ConfluxScan is activating its new domain. Check official announcement: https://forum.conflux.fun/t/confluxscan-domain-update-announcement-march-28-2025/21920

This PR updates the confluxscan url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated token explorer URLs to direct users to the new ConfluxScan website.
- **Documentation**
	- Revised release information to reflect the updated ConfluxScan URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->