### PR TITLE
<fix>: Improve the compatibility of shell.nix for different versions of Nix; fix overflow issue of micropython

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -19,10 +19,10 @@ let
     sha256 = "02s3qkb6kz3ndyx7rfndjbvp4vlwiqc42fxypn3g6jnc0v5jyz95";
   }) { };
   # commit emulator works fine
-  # sdlnixpkgs = import (builtins.fetchTarball {
-  #   url = "https://github.com/NixOS/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz";
-  #   sha256 = "0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i";
-  # }) { };
+  sdlnixpkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz";
+    sha256 = "0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i";
+  }) { };
   moneroTests = nixpkgs.fetchurl {
     url = "https://github.com/ph4r05/monero/releases/download/v0.18.1.1-dev-tests-u18.04-02/trezor_tests";
     sha256 = "81424cfc3965abdc24de573274bf631337b52fd25cefc895513214c613fe05c9";
@@ -77,8 +77,6 @@ stdenvNoCC.mkDerivation ({
     oldPythonNixpkgs.python37
     oldPythonNixpkgs.python36
   ] ++ [
-    SDL2
-    SDL2_image
     bash
     check
     curl  # for connect tests
@@ -102,11 +100,15 @@ stdenvNoCC.mkDerivation ({
     zlib
     moreutils
   ] ++ lib.optionals (!stdenv.isDarwin) [
+    SDL2
+    SDL2_image
     autoPatchelfHook
     gcc11
     procps
     valgrind
   ] ++ lib.optionals (stdenv.isDarwin) [
+    sdlnixpkgs.SDL2
+    sdlnixpkgs.SDL2_image
     darwin.apple_sdk.frameworks.CoreAudio
     darwin.apple_sdk.frameworks.AudioToolbox
     darwin.apple_sdk.frameworks.ForceFeedback

--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -19,10 +19,10 @@ let
     sha256 = "02s3qkb6kz3ndyx7rfndjbvp4vlwiqc42fxypn3g6jnc0v5jyz95";
   }) { };
   # commit emulator works fine
-  sdlnixpkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz";
-    sha256 = "0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i";
-  }) { };
+  # sdlnixpkgs = import (builtins.fetchTarball {
+  #   url = "https://github.com/NixOS/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz";
+  #   sha256 = "0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i";
+  # }) { };
   moneroTests = nixpkgs.fetchurl {
     url = "https://github.com/ph4r05/monero/releases/download/v0.18.1.1-dev-tests-u18.04-02/trezor_tests";
     sha256 = "81424cfc3965abdc24de573274bf631337b52fd25cefc895513214c613fe05c9";
@@ -57,7 +57,11 @@ let
   };
   llvmPackages = nixpkgs.llvmPackages_15;
   # see pyright/README.md for update procedure
-  pyright = nixpkgs.callPackage ./pyright {};
+  pyrightpath = builtins.pathExists ./pyright;
+  pyright = if pyrightpath then
+    nixpkgs.callPackage ./pyright {}
+  else
+    nixpkgs.callPackage ./ci/pyright {};
 in
 with nixpkgs;
 stdenvNoCC.mkDerivation ({
@@ -73,8 +77,8 @@ stdenvNoCC.mkDerivation ({
     oldPythonNixpkgs.python37
     oldPythonNixpkgs.python36
   ] ++ [
-    sdlnixpkgs.SDL2
-    sdlnixpkgs.SDL2_image
+    SDL2
+    SDL2_image
     bash
     check
     curl  # for connect tests

--- a/core/embed/unix/main.c
+++ b/core/embed/unix/main.c
@@ -495,7 +495,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
 #endif
 
 #if MICROPY_ENABLE_PYSTACK
-  static mp_obj_t pystack[1024];
+  static mp_obj_t pystack[4096];
   mp_pystack_init(pystack, &pystack[MP_ARRAY_SIZE(pystack)]);
 #endif
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated environment configuration to use SDL2 and SDL2_image from the main package set, with platform-specific adjustments.
  - Improved flexibility for selecting the pyright package based on local directory presence.

- **Refactor**
  - Increased the size of the MicroPython pystack for enhanced performance and stability in the Unix embedding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->